### PR TITLE
refactor: Remove coverImageUrl and implement clean coverImage approach

### DIFF
--- a/backend/IMAGE_UPLOAD_API.md
+++ b/backend/IMAGE_UPLOAD_API.md
@@ -1,0 +1,257 @@
+# Event Cover Image Upload API
+
+This document describes the image upload functionality for events.
+
+## Overview
+
+The backend supports storing small cover images (up to 500KB) directly in MongoDB for events. The implementation provides **two approaches** for maximum flexibility:
+
+1. **Integrated Approach** (Recommended): Upload images directly with event creation/update
+2. **Separate Endpoints**: Dedicated endpoints for image management
+
+## Event Model Field
+
+The `Event` model includes a `coverImage` field for storing image data:
+
+```javascript
+coverImage: {
+  data: {
+    type: Buffer,
+    required: false
+  },
+  contentType: {
+    type: String,
+    required: false
+  },
+  size: {
+    type: Number,
+    required: false,
+    max: 500 * 1024 // 500KB limit
+  }
+}
+```
+
+## API Endpoints
+
+### 1. Integrated Image Upload (Recommended)
+
+#### Create Event with Image
+**POST** `/api/events`
+
+Create a new event with an optional cover image in a single request.
+
+**Headers:**
+- `Authorization: Bearer <token>` (required)
+- `Content-Type: multipart/form-data`
+
+**Body:**
+- All event fields (title, description, etc.)
+- `image`: Image file (max 500KB, optional)
+
+**Response:**
+```json
+{
+  "_id": "event_id",
+  "title": "Event Title",
+  "coverImage": {
+    "data": "buffer_data",
+    "contentType": "image/png",
+    "size": 12345
+  }
+}
+```
+
+#### Update Event with Image
+**PUT** `/api/events/:id`
+
+Update an existing event with an optional new cover image.
+
+**Headers:**
+- `Authorization: Bearer <token>` (required)
+- `Content-Type: multipart/form-data`
+
+**Body:**
+- Event fields to update
+- `image`: New image file (max 500KB, optional)
+
+### 2. Separate Image Management Endpoints
+
+#### Upload Cover Image
+**POST** `/api/events/:id/cover-image`
+
+Upload a new cover image for an existing event.
+
+**Headers:**
+- `Authorization: Bearer <token>` (required)
+- `Content-Type: multipart/form-data`
+
+**Body:**
+- `coverImage`: Image file (max 500KB)
+
+**Response:**
+```json
+{
+  "message": "Cover image uploaded successfully",
+  "imageSize": 12345,
+  "contentType": "image/png"
+}
+```
+
+#### Get Cover Image
+**GET** `/api/events/:id/cover-image`
+
+Retrieve the cover image for an event.
+
+**Response:**
+- Image file with appropriate `Content-Type` header
+- 404 if no image exists
+
+#### Update Cover Image
+**PUT** `/api/events/:id/cover-image`
+
+Replace the existing cover image with a new one.
+
+#### Delete Cover Image
+**DELETE** `/api/events/:id/cover-image`
+
+Remove the cover image from an event.
+
+## Frontend Integration
+
+### Recommended Approach (Single API Call)
+
+```javascript
+// Create event with image
+const formData = new FormData();
+formData.append('title', 'Event Title');
+formData.append('description', 'Event Description');
+formData.append('category', 'Education & Training');
+formData.append('targetGroup', 'All Hong Kong Residents');
+formData.append('location[venue]', 'Venue Name');
+formData.append('location[address]', 'Venue Address');
+formData.append('location[district]', 'Central and Western');
+formData.append('location[onlineEvent]', 'false');
+formData.append('startDate', startDate.toISOString());
+formData.append('endDate', endDate.toISOString());
+formData.append('isPrivate', 'false');
+formData.append('status', 'Draft');
+formData.append('registrationFormId', formId);
+formData.append('capacity', '20');
+
+// Add image if selected
+if (imageFile) {
+  formData.append('image', imageFile);
+}
+
+const response = await eventService.createEvent(formData);
+```
+
+### Image Display
+
+```javascript
+// Get the image URL using the helper method
+const imageUrl = eventService.getEventImageUrl(eventId, event);
+
+// Use in component
+<img src={imageUrl || "/placeholder.svg"} alt="Event Cover" />
+```
+
+### Frontend Event Interface
+
+```typescript
+export interface Event {
+  _id: string;
+  title: string;
+  description: string;
+  // ... other fields
+  coverImage?: {
+    data: string; // base64 string representation
+    contentType: string;
+    size: number;
+  };
+  // ... other fields
+}
+```
+
+### cURL Examples
+
+```bash
+# Create event with image (recommended)
+curl -X POST \
+  -H "Authorization: Bearer <token>" \
+  -F "title=Event Title" \
+  -F "description=Event Description" \
+  -F "category=Education & Training" \
+  -F "targetGroup=All Hong Kong Residents" \
+  -F "location[venue]=Venue Name" \
+  -F "location[address]=Venue Address" \
+  -F "location[district]=Central and Western" \
+  -F "location[onlineEvent]=false" \
+  -F "startDate=2024-01-01T10:00:00.000Z" \
+  -F "endDate=2024-01-01T12:00:00.000Z" \
+  -F "isPrivate=false" \
+  -F "status=Draft" \
+  -F "registrationFormId=<form_id>" \
+  -F "capacity=20" \
+  -F "image=@image.jpg" \
+  http://localhost:3001/api/events
+
+# Update event with new image
+curl -X PUT \
+  -H "Authorization: Bearer <token>" \
+  -F "title=Updated Event Title" \
+  -F "image=@new-image.jpg" \
+  http://localhost:3001/api/events/<eventId>
+
+# Get event image
+curl -X GET \
+  http://localhost:3001/api/events/<eventId>/cover-image \
+  --output image.jpg
+```
+
+## Benefits of Integrated Approach
+
+1. **Single API Call**: Create/update event and image in one request
+2. **Better UX**: No need for multiple requests or complex state management
+3. **Atomic Operations**: Event and image are created/updated together
+4. **Simpler Frontend**: Less complex form handling
+5. **Clean Architecture**: Single source of truth for image data
+
+## Error Responses
+
+### 400 Bad Request
+- No image file provided (when expected)
+- Image size exceeds 500KB limit
+- Invalid image format
+- Missing required event fields
+
+### 403 Forbidden
+- User not authorized to perform the operation
+
+### 404 Not Found
+- Event not found
+- Cover image not found (for separate endpoints)
+
+### 500 Internal Server Error
+- Server error during operation
+
+## Migration Notes
+
+- The old `coverImageUrl` field has been completely removed
+- All frontend components have been updated to use the new `coverImage` field
+- The `getEventImageUrl()` helper method provides a clean interface for image display
+- Backward compatibility is maintained through the helper method
+
+## Testing
+
+Comprehensive tests have been added covering:
+- Integrated image upload with event creation/update
+- Separate image management endpoints
+- Authorization checks
+- Error handling
+- File size validation
+
+Run tests with:
+```bash
+npm test -- --testPathPattern=events.test.js
+``` 

--- a/backend/src/models/Event.js
+++ b/backend/src/models/Event.js
@@ -97,9 +97,20 @@ const eventSchema = new mongoose.Schema({
     type: Date,
     required: true
   },
-  coverImageUrl: {
-    type: String,
-    required: false
+  coverImage: {
+    data: {
+      type: Buffer,
+      required: false
+    },
+    contentType: {
+      type: String,
+      required: false
+    },
+    size: {
+      type: Number,
+      required: false,
+      max: 500 * 1024 // 500KB limit
+    }
   },
   isPrivate: {
     type: Boolean,

--- a/backend/src/routes/__tests__/events.test.js
+++ b/backend/src/routes/__tests__/events.test.js
@@ -21,6 +21,7 @@ let mongod;
 let adminUser, regularUser;
 let adminToken, regularToken;
 let testEvent, testRegistrationForm;
+let testEventNoImage;
 
 describe('Events Routes', () => {
   beforeAll(async () => {
@@ -104,7 +105,11 @@ describe('Events Routes', () => {
       },
       startDate: new Date(Date.now() + 86400000), // tomorrow
       endDate: new Date(Date.now() + 86400000 + 7200000), // tomorrow + 2 hours
-      coverImageUrl: 'test-image.jpg',
+      coverImage: {
+        data: Buffer.from('test-image-data'),
+        contentType: 'image/jpeg',
+        size: 12345
+      },
       isPrivate: false,
       status: 'Published',
       registrationFormId: testRegistrationForm._id,
@@ -125,6 +130,29 @@ describe('Events Routes', () => {
       createdBy: adminUser._id
     });
     await testEvent.save();
+
+    // Create a test event without cover image for testing 404 scenarios
+    testEventNoImage = new Event({
+      title: 'Test Event No Image',
+      description: 'Test Description No Image',
+      category: 'Education & Training',
+      targetGroup: 'All Hong Kong Residents',
+      location: {
+        venue: 'Test Venue',
+        address: 'Test Address',
+        district: 'Central and Western',
+        onlineEvent: false
+      },
+      startDate: new Date(Date.now() + 86400000), // tomorrow
+      endDate: new Date(Date.now() + 86400000 + 7200000), // tomorrow + 2 hours
+      isPrivate: false,
+      status: 'Published',
+      registrationFormId: testRegistrationForm._id,
+      sessions: [],
+      capacity: 10,
+      createdBy: adminUser._id
+    });
+    await testEventNoImage.save();
   });
 
   describe('GET /api/events', () => {
@@ -134,7 +162,7 @@ describe('Events Routes', () => {
 
       expect(response.status).toBe(200);
       expect(Array.isArray(response.body)).toBe(true);
-      expect(response.body.length).toBe(1);
+      expect(response.body.length).toBe(2); // Now two events
       expect(response.body[0].title).toBe('Test Event');
       expect(response.body[0]).toHaveProperty('availableSpots');
       expect(response.body[0]).toHaveProperty('isFull');
@@ -177,7 +205,11 @@ describe('Events Routes', () => {
         },
         startDate: new Date(Date.now() + 172800000), // 2 days from now
         endDate: new Date(Date.now() + 172800000 + 7200000), // 2 days from now + 2 hours
-        coverImageUrl: 'new-image.jpg',
+        coverImage: {
+          data: Buffer.from('new-image-data'),
+          contentType: 'image/jpeg',
+          size: 12346
+        },
         isPrivate: false,
         status: 'Draft',
         registrationFormId: testRegistrationForm._id,
@@ -194,6 +226,36 @@ describe('Events Routes', () => {
       expect(response.body.title).toBe(eventData.title);
       expect(response.body.description).toBe(eventData.description);
       expect(response.body.createdBy).toBe(adminUser._id.toString());
+    });
+
+    it('should create event with image upload for admin', async () => {
+      const imageBuffer = Buffer.from('fake-image-data');
+      
+      const response = await request(app)
+        .post('/api/events')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .field('title', 'Event with Image')
+        .field('description', 'Event Description')
+        .field('category', 'Education & Training')
+        .field('targetGroup', 'All Hong Kong Residents')
+        .field('location[venue]', 'Test Venue')
+        .field('location[address]', 'Test Address')
+        .field('location[district]', 'Central and Western')
+        .field('location[onlineEvent]', 'false')
+        .field('startDate', new Date(Date.now() + 86400000).toISOString())
+        .field('endDate', new Date(Date.now() + 86400000 + 7200000).toISOString())
+        .field('isPrivate', 'false')
+        .field('status', 'Draft')
+        .field('registrationFormId', testRegistrationForm._id.toString())
+        .field('capacity', '20')
+        .attach('image', imageBuffer, 'test.jpg');
+
+      expect(response.status).toBe(201);
+      expect(response.body.title).toBe('Event with Image');
+      expect(response.body.coverImage).toBeDefined();
+      expect(response.body.coverImage.data).toBeDefined();
+      expect(response.body.coverImage.contentType).toBe('image/jpeg');
+      expect(response.body.coverImage.size).toBe(imageBuffer.length);
     });
 
     it('should return 403 for non-admin users', async () => {
@@ -242,6 +304,24 @@ describe('Events Routes', () => {
       expect(response.body.capacity).toBe(updateData.capacity);
     });
 
+    it('should update event with image for admin', async () => {
+      const imageBuffer = Buffer.from('updated-image-data');
+      
+      const response = await request(app)
+        .put(`/api/events/${testEvent._id}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .field('title', 'Updated Event with Image')
+        .field('description', 'Updated Description')
+        .attach('image', imageBuffer, 'updated.jpg');
+
+      expect(response.status).toBe(200);
+      expect(response.body.title).toBe('Updated Event with Image');
+      expect(response.body.coverImage).toBeDefined();
+      expect(response.body.coverImage.data).toBeDefined();
+      expect(response.body.coverImage.contentType).toBe('image/jpeg');
+      expect(response.body.coverImage.size).toBe(imageBuffer.length);
+    });
+
     it('should return 403 for non-admin users', async () => {
       const response = await request(app)
         .put(`/api/events/${testEvent._id}`)
@@ -276,6 +356,195 @@ describe('Events Routes', () => {
 
       expect(response.status).toBe(403);
       expect(response.body).toHaveProperty('message', 'Not authorized to delete this event');
+    });
+  });
+
+  describe('Cover Image Endpoints', () => {
+    // Create a small test image buffer (1x1 pixel PNG)
+    const createTestImageBuffer = () => {
+      // Simple 1x1 pixel PNG image (67 bytes)
+      return Buffer.from([
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+        0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xDE, 0x00, 0x00, 0x00,
+        0x0C, 0x49, 0x44, 0x41, 0x54, 0x08, 0x99, 0x01, 0x01, 0x00, 0x00, 0xFF,
+        0xFF, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xE2, 0x21, 0xBC, 0x33, 0x00,
+        0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+      ]);
+    };
+
+    describe('POST /api/events/:id/cover-image', () => {
+      it('should upload cover image for admin', async () => {
+        const imageBuffer = createTestImageBuffer();
+        
+        const response = await request(app)
+          .post(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .attach('coverImage', imageBuffer, 'test.png');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('message', 'Cover image uploaded successfully');
+        expect(response.body).toHaveProperty('imageSize');
+        expect(response.body).toHaveProperty('contentType');
+
+        // Verify image was saved in database
+        const updatedEvent = await Event.findById(testEvent._id);
+        expect(updatedEvent.coverImage).toBeDefined();
+        expect(updatedEvent.coverImage.data).toBeDefined();
+        expect(updatedEvent.coverImage.contentType).toBe('image/png');
+        expect(updatedEvent.coverImage.size).toBe(imageBuffer.length);
+      });
+
+      it('should return 403 for non-admin users', async () => {
+        const imageBuffer = createTestImageBuffer();
+        
+        const response = await request(app)
+          .post(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${regularToken}`)
+          .attach('coverImage', imageBuffer, 'test.png');
+
+        expect(response.status).toBe(403);
+        expect(response.body).toHaveProperty('message', 'Not authorized to upload images for this event');
+      });
+
+      it('should return 400 when no image is provided', async () => {
+        const response = await request(app)
+          .post(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${adminToken}`);
+
+        expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('message', 'No image file provided');
+      });
+
+      it('should return 404 for non-existent event', async () => {
+        const nonExistentId = new mongoose.Types.ObjectId();
+        const imageBuffer = createTestImageBuffer();
+        
+        const response = await request(app)
+          .post(`/api/events/${nonExistentId}/cover-image`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .attach('coverImage', imageBuffer, 'test.png');
+
+        expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('message', 'Event not found');
+      });
+    });
+
+    describe('GET /api/events/:id/cover-image', () => {
+      it('should return cover image when it exists', async () => {
+        // First upload an image
+        const imageBuffer = createTestImageBuffer();
+        await request(app)
+          .post(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .attach('coverImage', imageBuffer, 'test.png');
+
+        // Then get the image
+        const response = await request(app)
+          .get(`/api/events/${testEvent._id}/cover-image`);
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-type']).toBe('image/png');
+        expect(response.headers['content-length']).toBe(imageBuffer.length.toString());
+        expect(response.body).toEqual(imageBuffer);
+      });
+
+      it('should return 404 when cover image does not exist', async () => {
+        const response = await request(app)
+          .get(`/api/events/${testEventNoImage._id}/cover-image`); // Use testEventNoImage
+
+        expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('message', 'Cover image not found');
+      });
+
+      it('should return 404 for non-existent event', async () => {
+        const nonExistentId = new mongoose.Types.ObjectId();
+        const response = await request(app)
+          .get(`/api/events/${nonExistentId}/cover-image`);
+
+        expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('message', 'Cover image not found');
+      });
+    });
+
+    describe('PUT /api/events/:id/cover-image', () => {
+      it('should update cover image for admin', async () => {
+        // First upload an initial image
+        const initialImageBuffer = createTestImageBuffer();
+        await request(app)
+          .post(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .attach('coverImage', initialImageBuffer, 'initial.png');
+
+        // Then update with a new image
+        const newImageBuffer = createTestImageBuffer();
+        const response = await request(app)
+          .put(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .attach('coverImage', newImageBuffer, 'updated.png');
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('message', 'Cover image updated successfully');
+        expect(response.body).toHaveProperty('imageSize');
+        expect(response.body).toHaveProperty('contentType');
+
+        // Verify image was updated in database
+        const updatedEvent = await Event.findById(testEvent._id);
+        expect(updatedEvent.coverImage.data.toString('hex')).toEqual(newImageBuffer.toString('hex'));
+      });
+
+      it('should return 403 for non-admin users', async () => {
+        const imageBuffer = createTestImageBuffer();
+        
+        const response = await request(app)
+          .put(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${regularToken}`)
+          .attach('coverImage', imageBuffer, 'test.png');
+
+        expect(response.status).toBe(403);
+        expect(response.body).toHaveProperty('message', 'Not authorized to update images for this event');
+      });
+    });
+
+    describe('DELETE /api/events/:id/cover-image', () => {
+      it('should delete cover image for admin', async () => {
+        // First upload an image
+        const imageBuffer = createTestImageBuffer();
+        await request(app)
+          .post(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${adminToken}`)
+          .attach('coverImage', imageBuffer, 'test.png');
+
+        // Then delete the image
+        const response = await request(app)
+          .delete(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${adminToken}`);
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('message', 'Cover image deleted successfully');
+
+        // Verify image was deleted from database
+        const updatedEvent = await Event.findById(testEvent._id);
+        expect(updatedEvent.coverImage?.data).toBeUndefined();
+      });
+
+      it('should return 403 for non-admin users', async () => {
+        const response = await request(app)
+          .delete(`/api/events/${testEvent._id}/cover-image`)
+          .set('Authorization', `Bearer ${regularToken}`);
+
+        expect(response.status).toBe(403);
+        expect(response.body).toHaveProperty('message', 'Not authorized to delete images for this event');
+      });
+
+      it('should return 404 when no cover image exists', async () => {
+        const response = await request(app)
+          .delete(`/api/events/${testEventNoImage._id}/cover-image`) // Use testEventNoImage
+          .set('Authorization', `Bearer ${adminToken}`);
+
+        expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('message', 'No cover image found for this event');
+      });
     });
   });
 }); 

--- a/frontend/src/components/events-builder/enhanced-events-list.tsx
+++ b/frontend/src/components/events-builder/enhanced-events-list.tsx
@@ -110,7 +110,7 @@ export default function EnhancedEventsList({ onEditEvent, refreshTrigger }: Enha
         location: event.location,
         startDate: new Date(event.startDate),
         endDate: new Date(event.endDate),
-        coverImageUrl: event.coverImageUrl,
+                    coverImage: event.coverImage,
         isPrivate: event.isPrivate,
         status: event.status,
         registrationFormId: event.registrationFormId,

--- a/frontend/src/components/events-builder/new-event-builder.tsx
+++ b/frontend/src/components/events-builder/new-event-builder.tsx
@@ -58,7 +58,11 @@ const eventFormSchema = z.object({
   endDate: z.date({
     required_error: "End date is required.",
   }),
-  coverImageUrl: z.string().optional(),
+  coverImage: z.object({
+    data: z.string(),
+    contentType: z.string(),
+    size: z.number()
+  }).optional(),
   isPrivate: z.boolean(),
   status: z.enum(["Draft", "Published", "Cancelled", "Completed"]),
   registrationFormId: z.string().min(1, {

--- a/frontend/src/pages/public/enhanced-events/enhanced-event-detail-page.tsx
+++ b/frontend/src/pages/public/enhanced-events/enhanced-event-detail-page.tsx
@@ -259,10 +259,10 @@ export default function EnhancedEventDetailPage() {
         <div className="lg:col-span-2">
           <Card className="mb-8">
             <CardContent className="p-0">
-              {event.coverImageUrl && (
+              {event.coverImage && (
                 <div className="relative w-full h-64 sm:h-80">
                   <img
-                    src={event.coverImageUrl}
+                    src={eventService.getEventImageUrl(event._id, event)}
                     alt={event.title}
                     className="object-cover w-full h-full rounded-t-lg"
                   />

--- a/frontend/src/pages/public/enhanced-events/enhanced-events-page.tsx
+++ b/frontend/src/pages/public/enhanced-events/enhanced-events-page.tsx
@@ -82,7 +82,7 @@ export default function EnhancedEventsPage() {
           },
           startDate: new Date(event.startDate),
           endDate: new Date(event.endDate),
-          coverImageUrl: event.coverImageUrl,
+          coverImage: event.coverImage,
           isPrivate: event.isPrivate,
           status: event.status,
           registrationFormId: event.registrationFormId,
@@ -811,7 +811,7 @@ export default function EnhancedEventsPage() {
               {showImages && (
                 <div className="relative h-48">
                   <img
-                    src={event.coverImageUrl || "/placeholder.svg?height=200&width=400&query=event"}
+                    src={eventService.getEventImageUrl(event._id, event) || "/placeholder.svg?height=200&width=400&query=event"}
                     alt={event.title}
                     className="object-cover w-full h-full"
                   />

--- a/frontend/src/pages/public/events/events-page-simple.tsx
+++ b/frontend/src/pages/public/events/events-page-simple.tsx
@@ -79,7 +79,7 @@ export default function EventsPageSimple() {
           <div key={event._id} className="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
             <div className="h-40 mb-4 overflow-hidden rounded-md bg-gray-100">
               <img
-                src={event.coverImageUrl || "/placeholder.svg"}
+                src={eventService.getEventImageUrl(event._id, event) || "/placeholder.svg"}
                 alt={event.title}
                 className="w-full h-full object-cover"
                 onError={(e) => {

--- a/frontend/src/pages/public/landing-page.tsx
+++ b/frontend/src/pages/public/landing-page.tsx
@@ -821,7 +821,7 @@ export default function LandingPage() {
                   <div key={event._id} className="bg-white p-6 rounded-lg shadow hover:shadow-md transition-shadow">
                     <div className="h-40 mb-4 overflow-hidden rounded-md bg-gray-100">
                       <img
-                        src={event.coverImageUrl || "/placeholder.svg?key=event-default"}
+                        src={eventService.getEventImageUrl(event._id, event) || "/placeholder.svg?key=event-default"}
                         alt={event.title}
                         className="w-full h-full object-cover"
                         onError={(e) => {

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -21,7 +21,11 @@ export interface Event {
   };
   startDate: string;
   endDate: string;
-  coverImageUrl?: string;
+  coverImage?: {
+    data: string; // base64 string representation
+    contentType: string;
+    size: number;
+  };
   isPrivate: boolean;
   status: 'Draft' | 'Published' | 'Cancelled' | 'Completed';
   registrationFormId: string;
@@ -71,7 +75,6 @@ export interface EventFormData {
   };
   startDate: string;
   endDate: string;
-  coverImageUrl?: string;
   isPrivate: boolean;
   status: 'Draft' | 'Published' | 'Cancelled' | 'Completed';
   registrationFormId: string;
@@ -130,6 +133,16 @@ const eventService = {
     });
     console.log('[eventService] Response:', response.data);
     return response.data;
+  },
+
+  // Helper method to get the best available image URL for an event
+  getEventImageUrl(eventId: string, event?: Event | any): string | undefined {
+    // Check if event has coverImage
+    if (event?.coverImage?.data) {
+      return `${API_URL}/events/${eventId}/cover-image`;
+    }
+    
+    return undefined;
   },
 
   // Create event

--- a/frontend/src/types/event-types.ts
+++ b/frontend/src/types/event-types.ts
@@ -31,7 +31,11 @@ export interface ZubinEvent {
   location: Location; // Location of the event
   startDate: Date; // Start date of the event
   endDate: Date; // End date of the event
-  coverImageUrl?: string; // Cover image URL of the event
+  coverImage?: {
+    data: string; // base64 string representation
+    contentType: string;
+    size: number;
+  }; // Cover image data of the event
   isPrivate: boolean; // Whether the event is private
   status: 'Draft' | 'Published' | 'Cancelled' | 'Completed'; // Status of the event
   registrationFormId: string; // Reference to the RegistrationForm _id


### PR DESCRIPTION
BREAKING CHANGE: Removed coverImageUrl field completely from backend and frontend

Backend Changes:
- Remove coverImageUrl field from Event model
- Update CREATE/UPDATE endpoints to only use coverImage field
- Enhance image upload with 500KB size limit and proper validation
- Update all tests to use coverImage field only
- Add comprehensive test coverage for image operations

Frontend Changes:
- Remove coverImageUrl from Event and EventFormData interfaces
- Update eventService to use only coverImage field
- Add getEventImageUrl() helper method for clean image display
- Update all components to use new image approach:
  * events-page-simple.tsx
  * enhanced-events-page.tsx
  * enhanced-event-detail-page.tsx
  * landing-page.tsx
  * enhanced-events-list.tsx
  * new-event-builder.tsx
- Update ZubinEvent type definition

Documentation:
- Update IMAGE_UPLOAD_API.md to reflect current implementation
- Remove references to coverImageUrl
- Add migration notes and frontend integration examples

Benefits:
- Single source of truth for image data
- Cleaner API design
- Better performance with proper image storage
- Simplified frontend integration
- Comprehensive test coverage