### PR TITLE
Fix Zubin Foundation URL to resolve 404 error

### DIFF
--- a/frontend/src/pages/public/landing-page.tsx
+++ b/frontend/src/pages/public/landing-page.tsx
@@ -938,7 +938,7 @@ export default function LandingPage() {
                 Join our community and help us transform the lives of ethnic minorities in Hong Kong.
               </p>
               <a
-                href="https://www.zubinfoundation.org/donate"
+                href="https://www.zubinfoundation.org/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-yellow-500 hover:text-yellow-600 font-medium inline-flex items-center"


### PR DESCRIPTION
## Fix Zubin Foundation URL

This PR fixes a 404 error on the landing page by updating the Zubin Foundation URL.

### ��� **Change Made**

- **Before**:  (404 error)
- **After**:  (working URL)

### ��� **Location**

- File: 
- Line: 941 (donate link in the footer section)

### ✅ **Impact**

- Resolves 404 error when users click on the Zubin Foundation link
- Ensures proper navigation to the foundation's website
- Improves user experience on the landing page

This is a simple but important fix to ensure users can properly access the Zubin Foundation website.